### PR TITLE
Support running the full CLI test suite.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ COPY go/parsec-hello-decrypt parsec-hello-decrypt
 RUN cd parsec-hello-decrypt && go get parsec/parsec-hello-decrypt && go build .
 
 FROM ubuntu:20.04
+RUN apt-get update
+# Install OpenSSL in support of the parsec-cli-tests.sh script, which can optionally be executed
+# by the client in place of the default hello-parsec.sh script.
+RUN apt-get -y install openssl
 WORKDIR /tools
 COPY --from=rustbuilder /tools/parsec-tool/target/release/parsec-tool .
 WORKDIR /app/rust

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ that it executes the `parsec-cli-tests.sh` script, which is included in the cont
 Running the container as follows will execute the tests:
 
 ```
-docker run -v /run/parsec:/run/parsec hello-parsec ./parsec-cli-tests.sh
+docker run --rm -v /run/parsec:/run/parsec hello-parsec ./parsec-cli-tests.sh
 ```
 
 When executed in this way, the output will be different from what is described above. The Parsec

--- a/README.md
+++ b/README.md
@@ -148,3 +148,20 @@ Hello Parsec from the Parsec CLI Tool!
 
 Finished!
 ```
+
+# Running More Extensive Tests
+
+The `hello-parsec` container can optionally be used to execute a full suite of functional tests in
+place of the default demo. This is achieved by supplying an override to the `docker run` command so
+that it executes the `parsec-cli-tests.sh` script, which is included in the container image.
+
+Running the container as follows will execute the tests:
+
+```
+docker run -v /run/parsec:/run/parsec hello-parsec ./parsec-cli-tests.sh
+```
+
+When executed in this way, the output will be different from what is described above. The Parsec
+logo and banner will not be displayed. Instead, the console will show all of the output from the
+command-line test script, which will include a variety of key management and cryptographic
+operations.

--- a/README.md
+++ b/README.md
@@ -165,3 +165,6 @@ When executed in this way, the output will be different from what is described a
 logo and banner will not be displayed. Instead, the console will show all of the output from the
 command-line test script, which will include a variety of key management and cryptographic
 operations.
+
+The `parsec-cli-tests.sh` script also accepts some command-line parameters to adjust its behaviour.
+You can use the `-h` option to get additional help on these.


### PR DESCRIPTION
Requires openssl to be included into the runtime base image, and a README change.

Signed-off-by: Paul Howard <paul.howard@arm.com>